### PR TITLE
Allow selecting which files to publish

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -15,6 +15,8 @@ jobs:
 
       - run: mkdir -p sdk
       - run: echo "module github.com/pulumi/publish-go-sdk-action/self-test" > sdk/go.mod
+      - run: echo "package main" > sdk/main.go
+      - run: echo "README" > sdk/README.md
 
       - uses: ./
         name: Publish Go SDK back to own repository
@@ -25,6 +27,9 @@ jobs:
           path: self-test
           version: 1.0.0-alpha.${{ github.run_number }}
           additive: false
+          files: |
+            go.mod
+            **/*.go
 
       - name: Clean up test tag
         run: git push origin --delete "self-test/v1.0.0-alpha.${{ github.run_number }}"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This action uses its own isolated checkout of the repository, so any original ch
     # Set to "true" to skip running `go get` on the newly pushed tag to ensure it is added to the go module cache.
     # Default: 'false'
     skip-go-get: false
+    # List of glob patterns to select Go source to be published. Defaults to "**" (all files).
+    files: "**"
 ```
 
 ## Examples

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   source:
     description: Path to the directory containing the Go source to be published. This folder should contain at least a go.mod file.
     required: true
+  files:
+    description: List of glob patterns to select Go source to be published. Defaults to "**" (all files).
+    default: "**"
   path:
     description: |
       Path within the repository to publish the go module (e.g. "sdk").
@@ -92,16 +95,18 @@ runs:
         run: mkdir -p "${{ inputs.path }}"
 
       - name: Copy files
-        shell: bash
-        working-directory: ${{ runner.temp }}/pulumi-publish-go-sdk-action
-        run: |
-          cp -r "${{ steps.abs_path.outputs.abs_path }}"/* "${{ inputs.path || '.' }}"
-          git add .
+        uses: pulumi/glob-action@v1
+        with:
+          operation: copy
+          source: ${{ steps.abs_path.outputs.abs_path }}
+          destination: ${{ runner.temp }}/pulumi-publish-go-sdk-action${{ inputs.path && format('/{0}', inputs.path) || '' }}
+          files: ${{ inputs.files || '**' }}
 
       - name: Commit
         shell: bash
         working-directory: ${{ runner.temp }}/pulumi-publish-go-sdk-action
         run: |
+          git add .
           git commit -m "v${{ inputs.version }}" --allow-empty
           git tag "${{ steps.git_tag.outputs.git_tag }}"
 


### PR DESCRIPTION
Allow the use of this action to customise which files from the source directory to copy and publish.

Conversation for context: https://github.com/pulumi/ci-mgmt/pull/920#issuecomment-2107887622