### PR TITLE
Make publishing idempotent

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -52,5 +52,15 @@ jobs:
           version: 2.0.0-alpha.${{ github.run_number }}
           additive: false
 
+      - uses: ./
+        name: Check running twice doesn't fail
+        with:
+          repository: ${{ github.repository }}
+          base-ref: ${{ github.sha }}
+          source: sdk
+          path: self-test
+          version: 2.0.0-alpha.${{ github.run_number }}
+          additive: false
+
       - name: Clean up test tag
         run: git push origin --delete "self-test/v2.0.0-alpha.${{ github.run_number }}"

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,14 @@ runs:
         shell: bash
         run: echo "git_tag=${{ inputs.path == '' && format('v{0}', inputs.version) || format('{0}/v{1}', inputs.path, inputs.version) }}" >> $GITHUB_OUTPUT
 
+      - name: Check if already exists
+        id: tag_exists
+        shell: bash
+        working-directory: ${{ runner.temp }}/pulumi-publish-go-sdk-action
+        run: |
+          echo -n "count=" >> $GITHUB_OUTPUT &&
+          git ls-remote --tags origin "${{ steps.git_tag.outputs.git_tag }}" >> $GITHUB_OUTPUT
+
       - name: Calculate absolute source path
         shell: bash
         id: abs_path
@@ -95,6 +103,7 @@ runs:
         run: mkdir -p "${{ inputs.path }}"
 
       - name: Copy files
+        if: steps.tag_exists.outputs.count == 0
         uses: pulumi/glob-action@v1
         with:
           operation: copy
@@ -104,6 +113,7 @@ runs:
 
       - name: Commit
         shell: bash
+        if: steps.tag_exists.outputs.count == 0
         working-directory: ${{ runner.temp }}/pulumi-publish-go-sdk-action
         run: |
           git add .
@@ -112,6 +122,7 @@ runs:
 
       - name: Push
         shell: bash
+        if: steps.tag_exists.outputs.count == 0
         working-directory: ${{ runner.temp }}/pulumi-publish-go-sdk-action
         run: |
           git push origin "${{ steps.git_tag.outputs.git_tag }}"

--- a/action.yml
+++ b/action.yml
@@ -138,3 +138,10 @@ runs:
           cd pulumi-publish-go-sdk-action-fetch
           go mod init github.com/pulumi/publish-go-sdk-action/fetch
           go get github.com/${{ inputs.repository }}${{ inputs.path == '' && '' || format('/{0}', inputs.path) }}${{ env.MODULE_SUFFIX }}@v${{ inputs.version }}
+
+      - name: Clean-up temp directory
+        if: always()
+        shell: bash
+        run: |
+          rm -rf "${{ runner.temp }}/pulumi-publish-go-sdk-action"
+          rm -rf "${{ runner.temp }}/pulumi-publish-go-sdk-action-fetch"


### PR DESCRIPTION
Fixes #6

- Skip pushing the SDK if the tag already exists.
- Always run the test to make sure the SDK is fetchable by Go.
- Add idempotent check to self-test.